### PR TITLE
Enable Asset Pipeline

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,10 @@ gem "jbuilder", "~> 2.7"
 # gem 'redis', '~> 4.0'
 # Use Active Model has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
+# Use Asset Pipeline Sprockets
+gem 'sprockets-rails'
+# Sass Compilation for Sprockets
+gem 'sass-rails'
 
 # Use Active Storage variant
 # gem 'image_processing', '~> 1.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -172,6 +172,16 @@ GEM
       rubocop-ast (>= 1.1.0)
     ruby-progressbar (1.10.1)
     rubyzip (2.3.0)
+    sass-rails (6.0.0)
+      sassc-rails (~> 2.1, >= 2.1.1)
+    sassc (2.4.0)
+      ffi (~> 1.9)
+    sassc-rails (2.1.2)
+      railties (>= 4.0.0)
+      sassc (>= 2.0)
+      sprockets (> 3.0)
+      sprockets-rails
+      tilt
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
@@ -188,6 +198,7 @@ GEM
       sprockets (>= 3.0.0)
     thor (1.0.1)
     thread_safe (0.3.6)
+    tilt (2.0.10)
     turbolinks (5.2.1)
       turbolinks-source (~> 5.2)
     turbolinks-source (5.2.0)
@@ -231,9 +242,11 @@ DEPENDENCIES
   rubocop-performance
   rubocop-rails
   rubocop-rspec
+  sass-rails
   selenium-webdriver
   spring
   spring-watcher-listen (~> 2.0.0)
+  sprockets-rails
   turbolinks (~> 5)
   tzinfo-data
   web-console (>= 3.3.0)

--- a/config/application.rb
+++ b/config/application.rb
@@ -14,7 +14,7 @@ require "action_mailbox/engine"
 require "action_text/engine"
 require "action_view/railtie"
 require "action_cable/engine"
-# require "sprockets/railtie"
+require "sprockets/railtie"
 require "rails/test_unit/railtie"
 
 # Require the gems listed in Gemfile, including any gems

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -27,6 +27,10 @@ Rails.application.configure do
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.action_controller.asset_host = 'http://assets.example.com'
 
+  # Compression methods for the Asset Pipeline
+  config.assets.css_compressor = :yui
+  config.assets.js_compressor = :uglifier
+
   # Specifies the header that your server uses for sending files.
   # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX


### PR DESCRIPTION
# Description
When the project was initialized I ask @cardotrejos  to add the `--skip-sprocekts`tag beacuse I was following a tutorial for using TailwindCSS with Rails without realizing they also used a JS Framework and that's why they didn't need the Asset Pipeline. As I started working with #6 I discovered I was unable to upload images using the  `image_tag` because the Asset Pipeline was disabled in the project.
I installed it using the steps provided in the [Rails Documentation](https://guides.rubyonrails.org/asset_pipeline.html).